### PR TITLE
Changed command order in dockerfile to speedup rebuilding process

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,21 @@
 FROM rocker/r-ver:latest
-MAINTAINER Julia Palm <julia.palm@med.uni-jena.de>
+
+# MAINTAINER Julia Palm <julia.palm@med.uni-jena.de>
 LABEL Description="PJT#6 smith2"
+LABEL Maintainer="julia.palm@med.uni-jena.de"
+
 RUN mkdir -p /Ergebnisse
 RUN mkdir -p /errors
 RUN mkdir -p /Bundles
-COPY config.R.default config.R.default
-COPY smith_select.R smith_select.R
-COPY install_R_packages.R install_R_packages.R
+
 RUN apt-get update -qq
 RUN apt-get install -yqq libxml2-dev libssl-dev curl
 RUN install2.r --error \
   --deps TRUE \
   fhircrackr
-  
-CMD Rscript smith_select.R
+
+COPY config.R.default config.R.default
+COPY smith_select.R smith_select.R
+COPY install_R_packages.R install_R_packages.R
+
+CMD ["Rscript", "smith_select.R"]


### PR DESCRIPTION
Now the libs and packages are installed first and afterwards the script is copied. So if only the script changes due to bugfixes or local adaptions, the build process will speed up dramatically.

And:
- Removed `MAINTAINER` from Dockerfile ([deprecated](https://docs.docker.com/engine/deprecated/#maintainer-in-dockerfile)) and used `LABEL` instead
- Updated `CMD` command ([see docker docs](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#cmd))