### PR TITLE
fix: added missing default config for `con_profile`

### DIFF
--- a/config.R.default
+++ b/config.R.default
@@ -33,4 +33,4 @@ enc_profile <- "&_profile=https://www.medizininformatik-initiative.de/fhir/core/
 obs_profile <- "&_profile=https://www.medizininformatik-initiative.de/fhir/core/modul-labor/StructureDefinition/ObservationLab"
 
 #Condition
-obs_profile <- "&_profile=https://www.medizininformatik-initiative.de/fhir/core/modul-diagnose/StructureDefinition/Diagnose"
+con_profile <- "&_profile=https://www.medizininformatik-initiative.de/fhir/core/modul-diagnose/StructureDefinition/Diagnose"


### PR DESCRIPTION
`con_profile` was missing in `config.R.default` (copy & paste error :see_no_evil:)